### PR TITLE
Protect controllers with JWT

### DIFF
--- a/Controllers/OrderDetailsController.cs
+++ b/Controllers/OrderDetailsController.cs
@@ -4,12 +4,14 @@ using CoreXCrud.Models;
 using CoreXCrud.Repositories;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CoreXCrud.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class OrderDetailsController : ControllerBase
+[Authorize] // 📌 JWT ile yetkilendirme ekledik
+[Route("api/[controller]")]
+[ApiController]
+public class OrderDetailsController : ControllerBase
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;

--- a/Controllers/OrdersController.cs
+++ b/Controllers/OrdersController.cs
@@ -4,13 +4,15 @@ using CoreXCrud.Models;
 using CoreXCrud.Repositories;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using Serilog;
 
 namespace CoreXCrud.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class OrdersController : ControllerBase
+[Authorize] // 📌 JWT ile yetkilendirme ekledik
+[Route("api/[controller]")]
+[ApiController]
+public class OrdersController : ControllerBase
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -4,12 +4,14 @@ using CoreXCrud.Models;
 using CoreXCrud.Repositories;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CoreXCrud.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class UsersController : ControllerBase
+[Authorize] // 📌 JWT ile yetkilendirme ekledik
+[Route("api/[controller]")]
+[ApiController]
+public class UsersController : ControllerBase
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ https://localhost:7252/swagger
 
 ## 📊 API Modülleri ve Uç Noktalar
 
+> **Not:** `/api/Auth/login` haricindeki tüm uç noktalar JWT ile korunur. İsteklerinizde `Authorization: Bearer {token}` başlığını göndermeniz gerekir.
+
 ### 🧑‍💼 1️⃣ Kullanıcı Yönetimi (Users)
 
 Kullanıcı yönetimi API'si, sistemdeki kullanıcıları yönetmek için kullanılır.


### PR DESCRIPTION
## Summary
- secure API controllers with `[Authorize]`
- note authentication requirement in docs

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484cb7df38833184d4c8aae1049269